### PR TITLE
Fix compliance with POSIX shells

### DIFF
--- a/src/cnf.sh
+++ b/src/cnf.sh
@@ -1,6 +1,6 @@
 # zsh
 if [ -n "${ZSH_NAME}" ]; then
-    function command_not_found_handler () {
+    command_not_found_handler () {
         if [ -x /usr/bin/cnf-lookup ]; then
             cnf-lookup -c $1
         fi
@@ -10,7 +10,7 @@ fi
 
 # bash
 if [ -n "${BASH}" ]; then
-    function command_not_found_handle () {
+    command_not_found_handle () {
         if [ -x /usr/bin/cnf-lookup ]; then
             cnf-lookup -c $1
             if [ ! $? -eq 0 ]; then


### PR DESCRIPTION
cnf.sh breaks GDM's session init script (and maybe other sh scripts) when [Dash](https://wiki.archlinux.org/index.php/Dash) is used for /bin/sh.
It is usually sourced from /etc/gdm/Xsession -> /etc/profile -> /etc/profile.d/cnf.sh.
(/etc/gdm/Xsession has #!/bin/sh for the header)
The breakage is due to cnf.sh using a POSIX-incompatible "function" bashism: https://wiki.ubuntu.com/DashAsBinSh#function

Simply removing the "function" keyword fixes the problem.
No regressions are introduced.
