### PR TITLE
forbid interpretation of commands as options

### DIFF
--- a/src/cnf.sh
+++ b/src/cnf.sh
@@ -2,7 +2,7 @@
 if [ -n "${ZSH_NAME}" ]; then
     command_not_found_handler () {
         if [ -x /usr/bin/cnf-lookup ]; then
-            cnf-lookup -c $1
+            cnf-lookup -c -- $1
         fi
         return 127
     }
@@ -12,7 +12,7 @@ fi
 if [ -n "${BASH}" ]; then
     command_not_found_handle () {
         if [ -x /usr/bin/cnf-lookup ]; then
-            cnf-lookup -c $1
+            cnf-lookup -c -- $1
             if [ ! $? -eq 0 ]; then
                 echo "bash: $1: command not found"
             fi


### PR DESCRIPTION
Using `-f` (or any other, nonexistent command starting with dashes) will get interpreted by cnf as an option. Using `--` in the parameters prevents this.

Some ugly pasty for understanding:

```
[bebe:~] % -f         
cnf-lookup: invalid option -- 'f'
       *** cnf 0.5.0 () ***       
Usage:                                                             
   cnf-lookup [ -d ] <search term>                                 
                                                                   
Options:                                                           
 --help            -? -h     Show this help and exit               
 --verbose         -v        Display verbose output                
                                                                   
 --database-path   -d        Customize the database lookup path    
                             default is /var/lib/cnf/    
 --colors          -c        Pretty colored output                 

zsh: command not found: -f
[bebe:~] 127 % 
```