### PR TITLE
Add support for completions in the fish shell

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -218,7 +218,7 @@ INSTALL (FILES cnf.fish
                         GROUP_READ
                         WORLD_READ
 						RENAME __fish_command_not_found_handler.fish
-            DESTINATION usr/share/fish/functions)
+            DESTINATION usr/share/fish/vendor_functions.d)
 
 INSTALL (FILES ${PROJECT_BINARY_DIR}/${BINARY_NAME}-sync
             PERMISSIONS OWNER_WRITE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,6 +212,13 @@ INSTALL (FILES cnf.sh
                         WORLD_READ
             DESTINATION etc/profile.d)
 
+INSTALL (FILES __fish_command_not_found_handler.fish
+            PERMISSIONS OWNER_WRITE
+                        OWNER_READ
+                        GROUP_READ
+                        WORLD_READ
+            DESTINATION usr/share/fish/functions)
+
 INSTALL (FILES ${PROJECT_BINARY_DIR}/${BINARY_NAME}-sync
             PERMISSIONS OWNER_WRITE
                         OWNER_EXECUTE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -212,11 +212,12 @@ INSTALL (FILES cnf.sh
                         WORLD_READ
             DESTINATION etc/profile.d)
 
-INSTALL (FILES __fish_command_not_found_handler.fish
+INSTALL (FILES cnf.fish
             PERMISSIONS OWNER_WRITE
                         OWNER_READ
                         GROUP_READ
                         WORLD_READ
+						RENAME __fish_command_not_found_handler.fish
             DESTINATION usr/share/fish/functions)
 
 INSTALL (FILES ${PROJECT_BINARY_DIR}/${BINARY_NAME}-sync

--- a/src/__fish_command_not_found_handler.fish
+++ b/src/__fish_command_not_found_handler.fish
@@ -1,0 +1,12 @@
+function __fish_command_not_found_handler --on-event fish_command_not_found
+	if test -x "/usr/bin/cnf-lookup"
+		cnf-lookup -c -- $argv[1]
+		if test $status -ne 0
+			__fish_default_command_not_found_handler $argv[1]
+		end
+	else
+		__fish_default_command_not_found_handler $argv[1]
+	end
+	# return 127 # This is actually unnecessary; fish handles it
+end
+

--- a/src/cnf.fish
+++ b/src/cnf.fish
@@ -7,6 +7,6 @@ function __fish_command_not_found_handler --on-event fish_command_not_found
 	else
 		__fish_default_command_not_found_handler $argv[1]
 	end
-	# return 127 # This is actually unnecessary; fish handles it
+	# no need to return an error code for fish
 end
 


### PR DESCRIPTION
This is a direct 1:1 port of your existing functions in cnf.sh, except it gets put in the global functions directory for fish.